### PR TITLE
feat: iframe implementation

### DIFF
--- a/src/Utils/render-iframe.ts
+++ b/src/Utils/render-iframe.ts
@@ -8,8 +8,8 @@ export function renderIframe(container: HTMLElement, config: TransakConfig) {
   Object.assign(iframe, {
     id: 'transakIframe',
     allow: 'camera;microphone;payment',
-    src: url
-  })
+    src: url,
+  });
 
   return container.appendChild(iframe);
 }

--- a/src/Utils/render-iframe.ts
+++ b/src/Utils/render-iframe.ts
@@ -1,0 +1,15 @@
+import { generateURL } from 'Utils/generate-url';
+import { TransakConfig } from 'Types/sdk-config.types';
+
+export function renderIframe(container: HTMLElement, config: TransakConfig) {
+  const url = generateURL(config);
+  const iframe = document.createElement('iframe');
+
+  Object.assign(iframe, {
+    id: 'transakIframe',
+    allow: 'camera;microphone;payment',
+    src: url
+  })
+
+  return container.appendChild(iframe);
+}

--- a/src/Utils/render-modal.ts
+++ b/src/Utils/render-modal.ts
@@ -6,9 +6,9 @@ export function renderModal(config: TransakConfig, closeRequest: () => void) {
 
   Object.assign(rootElement, {
     id: 'transakRoot',
-    onclick: () => closeRequest()
-  })
-  
+    onclick: () => closeRequest(),
+  });
+
   const modal = document.createElement('div');
   modal.innerHTML = `
     <div class="transak-modal">
@@ -21,6 +21,6 @@ export function renderModal(config: TransakConfig, closeRequest: () => void) {
 
   return {
     rootElement,
-    modal
+    modal,
   };
 }

--- a/src/Utils/render-modal.ts
+++ b/src/Utils/render-modal.ts
@@ -1,23 +1,26 @@
 import { closeIcon } from 'Assets/svg/close-icon';
-import { generateURL } from 'Utils/generate-url';
 import { TransakConfig } from 'Types/sdk-config.types';
 
 export function renderModal(config: TransakConfig, closeRequest: () => void) {
-  const url = generateURL(config);
-  const modal = document.createElement('div');
+  const rootElement = document.createElement('div');
 
-  modal.id = 'transakRoot';
+  Object.assign(rootElement, {
+    id: 'transakRoot',
+    onclick: () => closeRequest()
+  })
+  
+  const modal = document.createElement('div');
   modal.innerHTML = `
     <div class="transak-modal">
       ${closeIcon}
-      <iframe id="transakIframe" allow="camera;microphone;payment" src="${url}"></iframe>
     </div>
   `;
-  modal.onclick = () => closeRequest();
 
-  document.getElementsByTagName('body')[0].appendChild(modal);
-
+  document.getElementsByTagName('body')[0].appendChild(rootElement);
   document.getElementById('transakCloseIcon')?.addEventListener('click', () => closeRequest());
 
-  return modal;
+  return {
+    rootElement,
+    modal
+  };
 }

--- a/src/transak.ts
+++ b/src/transak.ts
@@ -5,6 +5,7 @@ import { setStyle } from 'Utils/set-style';
 import { renderModal } from 'Utils/render-modal';
 import { makeHandleMessage } from 'Utils/handle-message';
 import { TransakConfig } from 'Types/sdk-config.types';
+import { renderIframe } from 'Utils/render-iframe';
 
 const eventEmitter = new events.EventEmitter();
 
@@ -16,6 +17,8 @@ class Transak {
   #rootElement?: HTMLDivElement;
 
   #iframeElement?: HTMLIFrameElement;
+
+  #modalElement?: HTMLElement;
 
   #handleMessage: (event: MessageEvent<{ event_id: Events; data: unknown }>) => void;
 
@@ -49,19 +52,44 @@ class Transak {
     }
   };
 
+  initIframe(container: HTMLElement) {
+    if(!(container instanceof Element)) throw new Error('[Transak SDK] => container is not Element');
+
+    if (!this.#isInitialized) {
+      this.#iframeElement = renderIframe(container, this.#config)
+      this.#isInitialized = true;
+      return this.#iframeElement!
+    }
+  }
+
   openModal = () => {
     window.addEventListener('message', this.#handleMessage);
 
     this.#styleElement = setStyle(this.#config);
-    this.#rootElement = renderModal(this.#config, this.#closeRequest);
-    this.#iframeElement = document.getElementById('transakIframe') as HTMLIFrameElement;
+    
+    const {
+      modal,
+      rootElement
+    } = renderModal(this.#config, this.#closeRequest);
+
+    this.#rootElement = rootElement
+    this.#modalElement = modal
+
+    this.#iframeElement = renderIframe(modal, this.#config)
+    
+    return {
+      modal: this.#modalElement,
+      modalRoot: this.#rootElement
+    }
   };
 
   close = () => {
     this.#styleElement?.remove();
     this.#rootElement?.remove();
+    this.#modalElement?.remove();
     this.#removeEventListener();
     this.#isInitialized = false;
+    this.#iframeElement = undefined
   };
 
   getUser = () => {

--- a/src/transak.ts
+++ b/src/transak.ts
@@ -53,34 +53,32 @@ class Transak {
   };
 
   initIframe(container: HTMLElement) {
-    if(!(container instanceof Element)) throw new Error('[Transak SDK] => container is not Element');
+    if (!(container instanceof Element)) throw new Error('[Transak SDK] => container is not Element');
 
     if (!this.#isInitialized) {
-      this.#iframeElement = renderIframe(container, this.#config)
+      this.#iframeElement = renderIframe(container, this.#config);
       this.#isInitialized = true;
-      return this.#iframeElement!
     }
+
+    return this.#iframeElement;
   }
 
   openModal = () => {
     window.addEventListener('message', this.#handleMessage);
 
     this.#styleElement = setStyle(this.#config);
-    
-    const {
-      modal,
-      rootElement
-    } = renderModal(this.#config, this.#closeRequest);
 
-    this.#rootElement = rootElement
-    this.#modalElement = modal
+    const { modal, rootElement } = renderModal(this.#config, this.#closeRequest);
 
-    this.#iframeElement = renderIframe(modal, this.#config)
-    
+    this.#rootElement = rootElement;
+    this.#modalElement = modal;
+
+    this.#iframeElement = renderIframe(modal, this.#config);
+
     return {
       modal: this.#modalElement,
-      modalRoot: this.#rootElement
-    }
+      modalRoot: this.#rootElement,
+    };
   };
 
   close = () => {
@@ -89,7 +87,7 @@ class Transak {
     this.#modalElement?.remove();
     this.#removeEventListener();
     this.#isInitialized = false;
-    this.#iframeElement = undefined
+    this.#iframeElement = undefined;
   };
 
   getUser = () => {


### PR DESCRIPTION
This method avoids redundant code by not replicating the entire frame functionality, improving code maintainability and reducing inconsistencies between modal and iframe behaviors. It's also convenient for custom modals.


Simple example usage for vue: 

```vue
<script setup lang="ts">
import { Transak } from '@transak/transak-sdk'

const transak = new Transak()
const frameContainerRef = ref<HTMLElement>()

onMounted(() => transak.initIframe(frameContainer.value!))
onUnmountend(() => transak.close())
</script>

<template>
  <div ref="frameContainer" class="h-full w-full"></div>
</template>

<style>
#transakIframe {
  @apply h-full w-full border-0 bg-white;
}
</style>

```